### PR TITLE
fix for sf7

### DIFF
--- a/src/NorbertTech/StaticContentGeneratorBundle/DependencyInjection/Configuration.php
+++ b/src/NorbertTech/StaticContentGeneratorBundle/DependencyInjection/Configuration.php
@@ -12,7 +12,7 @@ final class Configuration implements ConfigurationInterface
     /**
      * @psalm-suppress UndefinedMethod
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('static_content_generator');
 

--- a/src/NorbertTech/StaticContentGeneratorBundle/StaticContent.php
+++ b/src/NorbertTech/StaticContentGeneratorBundle/StaticContent.php
@@ -20,7 +20,7 @@ final class StaticContent
         $this->writer = $writer;
     }
 
-    public function dump(Source $source, callable $callback = null) : void
+    public function dump(Source $source, ?callable $callback = null) : void
     {
         $this->writer->write(
             $content = $this->transformer->transform($source)


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Fixed</h4>  
  <ul id="fixed">
   <li>Changed declaration of NorbertTech\StaticContentGeneratorBundle\DependencyInjection\Configuration::getConfigTreeBuilder() to be compatible with Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()</li>
<li>Changed method signature from `callable $callback = null` to `?callable $callback = null`
to explicitly accept null and avoid type errors. Supported since PHP 7.1.</li>
  </ul>
</div>